### PR TITLE
43: Uses `viem` for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "tsup": "^8.5.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.1",
+        "viem": "^2.31.7",
         "vite": "^7.0.0",
         "vitest": "^3.2.4"
       },
@@ -2924,6 +2925,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.9.2",
       "license": "MIT",
@@ -4128,6 +4141,33 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "license": "MIT",
@@ -4771,6 +4811,27 @@
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/abort-controller": {
@@ -7480,6 +7541,21 @@
         "react-native-securerandom": "^0.1.1"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "devOptional": true,
@@ -9110,6 +9186,42 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.8.1.tgz",
+      "integrity": "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.8",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "dev": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -11223,6 +11335,57 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.31.7",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.7.tgz",
+      "integrity": "sha512-mpB8Hp6xK77E/b/yJmpAIQcxcOfpbrwWNItjnXaIA8lxZYt4JS433Pge2gg6Hp3PwyFtaUMh01j5L8EXnLTjQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.8.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.1",
+    "viem": "^2.31.7",
     "vite": "^7.0.0",
     "vitest": "^3.2.4"
   },

--- a/test-mocks/test-signature-fn.ts
+++ b/test-mocks/test-signature-fn.ts
@@ -1,5 +1,15 @@
-import { TypedDataField, Wallet } from "ethers";
+import { privateKeyToAccount } from "viem/accounts";
 import { SignatureFn } from "../src/types/param-types";
+import { hexToBigInt, TypedDataDomain } from "viem";
+import { EIP712Document } from "../src/types/signed-document-types";
+
+const toViemCompatibleDomain = (inputDomain: EIP712Document["domain"]): TypedDataDomain => {
+  const { chainId: sourceChainId, verifyingContract: sourceVerifyingContract, ...restDomain } = inputDomain
+  const chainId = hexToBigInt(sourceChainId as `0x${string}`)
+  const verifyingContract = sourceVerifyingContract as `0x${string}`
+
+  return { chainId, verifyingContract, ...restDomain }
+}
 
 /**
  * Test signature function
@@ -8,29 +18,30 @@ import { SignatureFn } from "../src/types/param-types";
  * @returns string
  */
 export const TEST_SIGNATURE_FN: SignatureFn = async (request) => {
-  // Alith: 0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac
-  const privateKey =
-    "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133";
-  const wallet = new Wallet(privateKey);
+  const account = privateKeyToAccount(
+    "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133"
+  );
 
   if (request.method === "personal_sign") {
     const [_address, message] = request.params;
-    return await wallet.signMessage(message);
+    return await account.signMessage({ message });
   }
+
   if (request.method === "eth_signTypedData_v4") {
     const [_address, typedData] = request.params;
+    const { domain, types, message } = typedData;
 
-    // Ethers forces this type to be removed
-    const types: Record<string, TypedDataField[]> = structuredClone(
-      typedData.types,
-    );
-    delete types["EIP712Domain"];
+    const updatedDomain = toViemCompatibleDomain(domain)
+    // Drop EIP712Domain from `types`
+    const { EIP712Domain: _, ...filteredTypes } = types;
 
-    return await wallet.signTypedData(
-      typedData.domain,
-      types,
-      typedData.message,
-    );
+    return await account.signTypedData({
+      domain: updatedDomain,
+      types: filteredTypes,
+      primaryType: typedData.primaryType,
+      message,
+    });
   }
+
   throw new Error("Incorrect method sent to the TEST_SIGNATURE_FN");
 };


### PR DESCRIPTION
Replaces usage of `ethers` in `test-mocks/test-signature-fn.ts` with `viem`

Closes #43 